### PR TITLE
Fix example (import, typo in func arg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Using this tool in your project, it returns an array for each file that include 
 #### Example
 
 ```js
-import fileSizes from 'filesizes';
+import { fileSizes } from 'filesizes';
+// const { fileSizes } = require("filesizes");
 
 const fileInfo = fileSizes();
-fileInfo.forEach(info => console.log(file.name, file.size));
+fileInfo.forEach(file => console.log(file.name, file.size));
 ```
 
 #### Options


### PR DESCRIPTION
Fixed typo in function argument and import had to have { }, since it's not default export
Also added the require() function too